### PR TITLE
Fixed link in Sneddon abstract

### DIFF
--- a/_posts/2022-12-19-sneddon22a.md
+++ b/_posts/2022-12-19-sneddon22a.md
@@ -11,7 +11,7 @@ abstract: 'Algorithms developed for basecalling Nanopore signals have primarily 
   of mRNA language is able to guide CTC beam search decoding towards the more probable
   nucleotide sequence.  We also propose a time efficient approach to decoding variable
   length nanopore signals.  This work provides the first demonstration of the potential
-  for biological language to inform Nanopore basecalling.  Code is available at: https://github.com/a-sneddon/radian.'
+  for biological language to inform Nanopore basecalling.  Code is available at:  https://github.com/comprna/radian.'
 title: Language-Informed Basecalling Architecture for Nanopore Direct RNA Sequencing
 layout: inproceedings
 series: Proceedings of Machine Learning Research


### PR DESCRIPTION
CMT gave us the old abstracts somehow. Fixing broken link to code. 